### PR TITLE
discographiesテーブルにlast_fetched_atカラムを追加

### DIFF
--- a/bin/scripts/004_fetch_touhou_music_using_the_apple_music_api.rb
+++ b/bin/scripts/004_fetch_touhou_music_using_the_apple_music_api.rb
@@ -49,6 +49,8 @@ def correct_touhou_music(discography)
     if discography.is_touhou && discography.songs.each.all? { |song| !song.is_touhou }
       discography.update(is_touhou: false)
     end
+
+    discography.update(last_fetched_at: Time.zone.now)
   end
 end
 
@@ -56,8 +58,11 @@ end
 album_count = 0
 discographies = Discography.order(updated_at: :desc)
 max_albums = discographies.count
+twelve_hours_ago = Time.zone.now.ago(12.hours)
 discographies.find_each do |discography|
-  correct_touhou_music(discography)
+  if discography.last_fetched_at.nil? || twelve_hours_ago > discography.last_fetched_at
+    correct_touhou_music(discography)
+  end
   album_count += 1
   print "\rアルバム: #{album_count}/#{max_albums} Progress: #{(album_count * 100.0 / max_albums).round(1)}%"
   sleep 0.5

--- a/db/migrate/20210409004953_add_last_fetched_at_to_discographies.rb
+++ b/db/migrate/20210409004953_add_last_fetched_at_to_discographies.rb
@@ -1,0 +1,5 @@
+class AddLastFetchedAtToDiscographies < ActiveRecord::Migration[6.1]
+  def change
+    add_column :discographies, :last_fetched_at, :datetime, limit: 6, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_04_024813) do
+ActiveRecord::Schema.define(version: 2021_04_09_004953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2021_04_04_024813) do
     t.string "apple_music_collection_name", default: "", null: false
     t.string "youtube_collection_name", default: "", null: false
     t.string "youtube_collection_view_url", default: "", null: false
+    t.datetime "last_fetched_at", precision: 6
     t.index ["apple_artist_id"], name: "index_discographies_on_apple_artist_id"
     t.index ["apple_collection_id"], name: "index_discographies_on_apple_collection_id", unique: true
   end


### PR DESCRIPTION
- discographiesテーブルにlast_fetched_atカラムを追加
  - Apple Music APIでの取得で、last_fetched_atを見るようにスクリプトを修正
     - 12時間以内のものは処理しないように修正
     - last_fetched_atがnilまたは、last_fetched_atが12時間以上前のものの場合、取得処理を実行するように修正